### PR TITLE
fix(RCTView): add missing dependency

### DIFF
--- a/ios/RNVideoProcessing/RNVideoProcessing.h
+++ b/ios/RNVideoProcessing/RNVideoProcessing.h
@@ -6,6 +6,7 @@
 #ifndef RNVideoProcessing_h
 #define RNVideoProcessing_h
 
+#import "React/RCTView.h"
 #import "SDAVAssetExportSession.h"
 #import "RNTrimmerView.h"
 


### PR DESCRIPTION
I think this should be within this project so the end developer doesn't have to add it to their bridging header.

P.S. Thanks for the RN 0.4x update!!