### PR TITLE
feat(RNVideoTrimmer): add option to save to camera roll with the current date and time

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
  [![Build Status](https://travis-ci.org/shahen94/react-native-video-processing.svg?branch=master)](https://travis-ci.org/shahen94/react-native-video-processing) [![semantic-release](https://img.shields.io/badge/%20%20%F0%9F%93%A6%F0%9F%9A%80-semantic--release-e10079.svg?style=plastic)](https://github.com/semantic-release/semantic-release) [![npm version](https://badge.fury.io/js/react-native-video-processing.svg)](https://badge.fury.io/js/react-native-video-processing) ![npm package](https://img.shields.io/npm/dm/react-native-video-processing.svg)
 
-### You can check test just running 
+### You can check test just running
 `$ npm test` or `$ yarn test`
 
 ### Manual installation
@@ -47,7 +47,8 @@ class App extends Component {
             startTime: 0,
             endTime: 15,
             quality: VideoPlayer.Constants.quality.QUALITY_1280x720,
-            saveToCameraRoll: true // default is false
+            saveToCameraRoll: true, // default is false
+            saveWithCurrentDate: true, // default is false
         };
         this.videoPlayerRef.trim(require('./videoFile.mp4'), options)
             .then((newSource) => console.log(newSource))
@@ -59,7 +60,8 @@ class App extends Component {
             width: 720,
             endTime: 1280,
             bitrateMultiplier: 3,
-            saveToCameraRoll: true // default is false
+            saveToCameraRoll: true, // default is false
+            saveWithCurrentDate: true, // default is false
             minimumBitrate: 300000
         };
         this.videoPlayerRef.compress(require('./videoFile.mp4'), options)

--- a/ios/RNVideoProcessing/RNVideoTrimmer/RNVideoTrimmer.swift
+++ b/ios/RNVideoProcessing/RNVideoTrimmer/RNVideoTrimmer.swift
@@ -27,6 +27,7 @@ class RNVideoTrimmer: NSObject {
         var eTime = options.object(forKey: "endTime") as? Float
         let quality = ((options.object(forKey: "quality") as? String) != nil) ? options.object(forKey: "quality") as! String : ""
         let saveToCameraRoll = options.object(forKey: "saveToCameraRoll") as? Bool ?? false
+        let saveWithCurrentDate = options.object(forKey: "saveWithCurrentDate") as? Bool ?? false
 
         let manager = FileManager.default
         guard let documentDirectory = try? manager.url(for: .documentDirectory, in: .userDomainMask, appropriateFor: nil, create: true)
@@ -69,6 +70,14 @@ class RNVideoTrimmer: NSObject {
         exportSession.outputFileType = AVFileTypeMPEG4
         exportSession.shouldOptimizeForNetworkUse = true
 
+        if saveToCameraRoll && saveWithCurrentDate {
+          let metaItem = AVMutableMetadataItem()
+          metaItem.key = AVMetadataCommonKeyCreationDate as (NSCopying & NSObjectProtocol)?
+          metaItem.keySpace = AVMetadataKeySpaceCommon
+          metaItem.value = NSDate() as (NSCopying & NSObjectProtocol)?
+          exportSession.metadata = [metaItem]
+        }
+
         let startTime = CMTime(seconds: Double(sTime!), preferredTimescale: 1000)
         let endTime = CMTime(seconds: Double(eTime!), preferredTimescale: 1000)
         let timeRange = CMTimeRange(start: startTime, end: endTime)
@@ -100,6 +109,7 @@ class RNVideoTrimmer: NSObject {
         let bitrateMultiplier = options.object(forKey: "bitrateMultiplier") as? Float ?? 1
         let saveToCameraRoll = options.object(forKey: "saveToCameraRoll") as? Bool ?? false
         let minimumBitrate = options.object(forKey: "minimumBitrate") as? Float
+        let saveWithCurrentDate = options.object(forKey: "saveWithCurrentDate") as? Bool ?? false
 
         let manager = FileManager.default
         guard let documentDirectory = try? manager.url(for: .documentDirectory, in: .userDomainMask, appropriateFor: nil, create: true)
@@ -151,6 +161,13 @@ class RNVideoTrimmer: NSObject {
         compressionEncoder!.outputFileType = AVFileTypeMPEG4
         compressionEncoder!.outputURL = NSURL.fileURL(withPath: outputURL.path)
         compressionEncoder!.shouldOptimizeForNetworkUse = true
+        if saveToCameraRoll && saveWithCurrentDate {
+          let metaItem = AVMutableMetadataItem()
+          metaItem.key = AVMetadataCommonKeyCreationDate as (NSCopying & NSObjectProtocol)?
+          metaItem.keySpace = AVMetadataKeySpaceCommon
+          metaItem.value = NSDate() as (NSCopying & NSObjectProtocol)?
+          compressionEncoder!.metadata = [metaItem]
+        }
         compressionEncoder?.videoSettings = [
             AVVideoCodecKey: AVVideoCodecH264,
             AVVideoWidthKey: NSNumber.init(value: width!),


### PR DESCRIPTION
## Problem

1. I pick a video from the camera roll a month old
2. Trim that video and save to camera roll with this library
3. The new video retains all the metadata from the original video, including creationDate
4. This makes the new video show in the camera roll next to the original video, which could by way back in the roll

## Solution

### A (my preference)

Change current default to always save the new video with the current date.
Optionally provide option to retain the original date.

### B (this PR)

Leave default behavior.
Add option to save with the current date.

**I wasn't sure if you would like solution A, so I tried this first. If you like A, I'll change this PR to that.**
