### PR TITLE
complete when getting a null frame instance

### DIFF
--- a/android/src/main/java/com/shahenlibrary/Trimmer/Trimmer.java
+++ b/android/src/main/java/com/shahenlibrary/Trimmer/Trimmer.java
@@ -86,6 +86,9 @@ public class Trimmer {
 
     for (int i = 0; i < duration; i += duration / 10) {
       Bitmap frame = retriever.getFrameAtTime(i * 1000);
+      if(frame == null) {
+        continue;
+      }
       Bitmap currBmp = Bitmap.createScaledBitmap(frame, resizeWidth, resizeHeight, false);
 
       Bitmap normalizedBmp = Bitmap.createBitmap(currBmp, 0, 0, resizeWidth, resizeHeight, mx, true);


### PR DESCRIPTION
This dodges the error that occurs on Android 5.1 and 6.0 when the bitmap data comes back null. 7 seemed to be getting around the bug some other way.