### PR TITLE
[android] Fix/ensure dimensions divideable by 2. Fixes #134

### DIFF
--- a/android/src/main/java/com/shahenlibrary/Trimmer/Trimmer.java
+++ b/android/src/main/java/com/shahenlibrary/Trimmer/Trimmer.java
@@ -75,7 +75,7 @@ public class Trimmer {
 
   private static final String LOG_TAG = "RNTrimmerManager";
   private static final String FFMPEG_FILE_NAME = "ffmpeg";
-  private static final String FFMPEG_SHA1 = "5b430b578e0fcd9903c3553d977aa99b5f461c7a";
+  private static final String FFMPEG_SHA1 = "77ae380db4bf56d011eca9ef9f20d397c0467aec";
 
   private static boolean ffmpegLoaded = false;
   private static final int DEFAULT_BUFFER_SIZE = 4096;


### PR DESCRIPTION
Hello @shahen94 !

I recompiled ffmpeg with all filters enabled (!). This adds 1.6 Mb
https://github.com/kesha-antonov/ffmpeg-android/commit/55f8997d28323b92fcf70128dac322fcaa59c4c8

If somebody in this rep knows more about ffmpeg and have time to compile with filters that we use then please ask him/her to do it.

It can reduce apk size by 1.5MB

For now it fixes https://github.com/shahen94/react-native-video-processing/issues/134

