### PR TITLE
Merging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 # MacOS temporary files
 .DS_Store
 
+# Webstorm
+.idea
+
 # Logs
 logs
 *.log

--- a/android/src/main/java/com/shahenlibrary/Trimmer/Trimmer.java
+++ b/android/src/main/java/com/shahenlibrary/Trimmer/Trimmer.java
@@ -34,6 +34,7 @@ import android.os.Build;
 import android.util.Base64;
 import android.util.Log;
 
+import com.facebook.react.bridge.ReadableArray;
 import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.Promise;
 import com.facebook.react.bridge.ReactApplicationContext;
@@ -737,6 +738,37 @@ public class Trimmer {
     cmd.add(tempFile.getPath());
 
     executeFfmpegCommand(cmd, tempFile.getPath(), ctx, promise, "Reverse error", null);
+  }
+
+  static void merge(ReadableArray videoFiles, String concatCmd, final Promise promise, ReactApplicationContext ctx) {
+    final File tempFile = createTempFile("mp4", promise, ctx);
+
+    Log.d(LOG_TAG, "Merging in progress.");
+
+    ArrayList<String> cmd = new ArrayList<String>();
+    cmd.add("-y"); // NOTE: OVERWRITE OUTPUT FILE
+
+    for (int i = 0; i < videoFiles.size(); i++) {
+      cmd.add("-i");
+      cmd.add(videoFiles.getString(i));
+    }
+
+    cmd.add("-filter_complex");
+    cmd.add(concatCmd);
+
+    cmd.add("-map");
+    cmd.add("[v]");
+
+    cmd.add("-preset");
+    cmd.add("ultrafast");
+
+    // NOTE: DO NOT CONVERT AUDIO TO SAVE TIME
+    cmd.add("-c:a");
+
+    cmd.add("copy");
+    cmd.add(tempFile.getPath());
+
+    executeFfmpegCommand(cmd, tempFile.getPath(), ctx, promise, "Merge error", null);
   }
 
   static private Void executeFfmpegCommand(@NonNull ArrayList<String> cmd, @NonNull final String pathToProcessingFile, @NonNull ReactApplicationContext ctx, @NonNull final Promise promise, @NonNull final String errorMessageTitle, @Nullable final OnCompressVideoListener cb) {

--- a/android/src/main/java/com/shahenlibrary/Trimmer/TrimmerManager.java
+++ b/android/src/main/java/com/shahenlibrary/Trimmer/TrimmerManager.java
@@ -26,6 +26,7 @@ package com.shahenlibrary.Trimmer;
 import android.support.annotation.NonNull;
 import android.util.Log;
 
+import com.facebook.react.bridge.ReadableArray;
 import com.facebook.react.bridge.Promise;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactContextBaseJavaModule;
@@ -98,6 +99,12 @@ public class TrimmerManager extends ReactContextBaseJavaModule {
   public void reverse(String path, Promise promise) {
     Log.d(REACT_PACKAGE, "reverse video: " + path);
     Trimmer.reverse(path, promise, reactContext);
+  }
+
+  @ReactMethod
+  public void merge(ReadableArray videoFiles, String cmd, Promise promise) {
+    Log.d(REACT_PACKAGE, "Sending command: " + cmd);
+    Trimmer.merge(videoFiles, cmd, promise, reactContext);
   }
 
   @ReactMethod

--- a/lib/ProcessingManager/ProcessingManager.android.js
+++ b/lib/ProcessingManager/ProcessingManager.android.js
@@ -3,6 +3,7 @@
 import { NativeModules } from 'react-native';
 import type {
   sourceType,
+  arrayType,
   trimOptions,
   previewMaxSize,
   format,
@@ -72,6 +73,10 @@ export class ProcessingManager {
     const actualSource: string = getActualSource(source);
     return TrimmerManager.crop(actualSource, options)
       .then((res) => res.source);
+  }
+
+  static merge(readableFiles: arrayType, cmd: string): Promise<string> {
+    return TrimmerManager.merge(readableFiles, cmd).then((res) => res.source);
   }
 
 }

--- a/lib/ProcessingManager/types.android.js
+++ b/lib/ProcessingManager/types.android.js
@@ -29,6 +29,8 @@ export type cropOptions = {
   // quality: ?trimQuality
 };
 
+export type arrayType = Array<string>;
+
 declare class RNTrimmerManager {
   static trim(source: string, options: trimOptions): Promise<{ source: string }>;
   static compress(source: string, options: any): Promise<*>;
@@ -36,4 +38,5 @@ declare class RNTrimmerManager {
   static getPreviewImages(source: string): Promise<*>;
   static getPreviewImageAtPosition(source: string, second: number): Promise<{ image: string }>;
   static crop(source: string, options: cropOptions): Promise<{ source: string }>;
+  static merge(source: arrayType, cmd: string): Promise<{ source: string }>;
 }


### PR DESCRIPTION
Hey @shahen94 - know you're not actively working on this anymore but was wondering if you had a few free moments if you could offer some guidance / tips on this PR, which is in part based on [this discussion](https://github.com/shahen94/react-native-video-processing/issues/83).

This branch works on Android but merging is extremely slow on my Samsung tablet (generally 6+ seconds). I haven't profiled but think it's on account of the `filter_complex` (which comes from the JS side and will look like `[0:0][1:0][2:0] concat=n=3:v=1 [v]` - ideally I'd refactor this to not call FFMPEG commands within React).

I'm not very familiar with FFMPEG, but based on my reading of the [docs](https://trac.ffmpeg.org/wiki/Concatenate) it seems like for videos with different codecs, `filter_complex` with `concat` is recommended.

Any advice on how to improve performance here or other thoughts would be great. If this can be faster, would be happy to add some tests and refactor as necessary if you think it's a good candidate for merging. Thanks again!