### PR TITLE
fix(android): Accept ThemedReactContext properly in commands to fix NPE.

### DIFF
--- a/android/src/main/java/com/shahenlibrary/Trimmer/Trimmer.java
+++ b/android/src/main/java/com/shahenlibrary/Trimmer/Trimmer.java
@@ -84,12 +84,12 @@ public class Trimmer {
   private static class FfmpegCmdAsyncTaskParams {
     ArrayList<String> cmd;
     final String pathToProcessingFile;
-    ReactApplicationContext ctx;
+    Context ctx;
     final Promise promise;
     final String errorMessageTitle;
     final OnCompressVideoListener cb;
 
-    FfmpegCmdAsyncTaskParams(ArrayList<String> cmd, final String pathToProcessingFile, ReactApplicationContext ctx, final Promise promise, final String errorMessageTitle, final OnCompressVideoListener cb) {
+    FfmpegCmdAsyncTaskParams(ArrayList<String> cmd, final String pathToProcessingFile, Context ctx, final Promise promise, final String errorMessageTitle, final OnCompressVideoListener cb) {
       this.cmd = cmd;
       this.pathToProcessingFile = pathToProcessingFile;
       this.ctx = ctx;
@@ -105,7 +105,7 @@ public class Trimmer {
     protected Void doInBackground(FfmpegCmdAsyncTaskParams... params) {
       ArrayList<String> cmd = params[0].cmd;
       final String pathToProcessingFile = params[0].pathToProcessingFile;
-      ReactApplicationContext ctx = params[0].ctx;
+      Context ctx = params[0].ctx;
       final Promise promise = params[0].promise;
       final String errorMessageTitle = params[0].errorMessageTitle;
       final OnCompressVideoListener cb = params[0].cb;
@@ -176,9 +176,9 @@ public class Trimmer {
 
 
   private static class LoadFfmpegAsyncTaskParams {
-    ReactApplicationContext ctx;
+    Context ctx;
 
-    LoadFfmpegAsyncTaskParams(ReactApplicationContext ctx) {
+    LoadFfmpegAsyncTaskParams(Context ctx) {
       this.ctx = ctx;
     }
   }
@@ -187,7 +187,7 @@ public class Trimmer {
 
     @Override
     protected Void doInBackground(LoadFfmpegAsyncTaskParams... params) {
-      ReactApplicationContext ctx = params[0].ctx;
+      Context ctx = params[0].ctx;
 
       // NOTE: 1. COPY "ffmpeg" FROM ASSETS TO /data/data/com.myapp...
       String filesDir = getFilesDirAbsolutePath(ctx);
@@ -515,7 +515,7 @@ public class Trimmer {
     }
     cmd.add(tempFile.getPath());
 
-    executeFfmpegCommand(cmd, tempFile.getPath(), rctx, promise, "compress error", cb);
+    executeFfmpegCommand(cmd, tempFile.getPath(), ctx, promise, "compress error", cb);
   }
 
   static File createTempFile(String extension, final Promise promise, Context ctx) {
@@ -739,7 +739,7 @@ public class Trimmer {
     executeFfmpegCommand(cmd, tempFile.getPath(), ctx, promise, "Reverse error", null);
   }
 
-  static private Void executeFfmpegCommand(@NonNull ArrayList<String> cmd, @NonNull final String pathToProcessingFile, @NonNull ReactApplicationContext ctx, @NonNull final Promise promise, @NonNull final String errorMessageTitle, @Nullable final OnCompressVideoListener cb) {
+  static private Void executeFfmpegCommand(@NonNull ArrayList<String> cmd, @NonNull final String pathToProcessingFile, @NonNull Context ctx, @NonNull final Promise promise, @NonNull final String errorMessageTitle, @Nullable final OnCompressVideoListener cb) {
     FfmpegCmdAsyncTaskParams ffmpegCmdAsyncTaskParams = new FfmpegCmdAsyncTaskParams(cmd, pathToProcessingFile, ctx, promise, errorMessageTitle, cb);
 
     FfmpegCmdAsyncTask ffmpegCmdAsyncTask = new FfmpegCmdAsyncTask();
@@ -748,11 +748,11 @@ public class Trimmer {
     return null;
   }
 
-  private static String getFilesDirAbsolutePath(ReactApplicationContext ctx) {
+  private static String getFilesDirAbsolutePath(Context ctx) {
     return ctx.getFilesDir().getAbsolutePath();
   }
 
-  private static String getFfmpegAbsolutePath(ReactApplicationContext ctx) {
+  private static String getFfmpegAbsolutePath(Context ctx) {
     return getFilesDirAbsolutePath(ctx) + File.separator + FFMPEG_FILE_NAME;
   }
 

--- a/android/src/main/java/com/shahenlibrary/VideoPlayer/VideoPlayerViewManager.java
+++ b/android/src/main/java/com/shahenlibrary/VideoPlayer/VideoPlayerViewManager.java
@@ -120,7 +120,7 @@ public class VideoPlayerViewManager extends SimpleViewManager<VideoPlayerView> {
   public void receiveCommand(VideoPlayerView root, int commandId, @Nullable ReadableArray args) {
     assert args != null;
     Log.d(VideoPlayerViewManager.REACT_PACKAGE, "receiveCommand: " + args.toString());
-    Log.d(VideoPlayerViewManager.REACT_PACKAGE, "receiveCommand: commandId" + String.valueOf(commandId));
+    Log.d(VideoPlayerViewManager.REACT_PACKAGE, "receiveCommand: commandId " + String.valueOf(commandId));
     switch (commandId) {
       case COMMAND_GET_INFO:
         root.sendMediaInfo();
@@ -138,6 +138,7 @@ public class VideoPlayerViewManager extends SimpleViewManager<VideoPlayerView> {
       case COMMAND_COMPRESS_MEDIA:
         ReadableMap options = args.getMap(0);
         root.compressMedia(this.reactContext, options);
+        break;
       default:
         Log.d(VideoPlayerViewManager.REACT_PACKAGE, "receiveCommand: Wrong command received");
     }


### PR DESCRIPTION
From `VideoEdit#startCompress`, `Trimmer#compress` is called with `ReactApplicationContext rctx` as null. Inside the method, either `ReactApplicationContext` or `ThemedReactContext` is selected, but the `executeFfmpegCommand` method was always being called with rctx. This change makes the Trimmer class accept either `ReactApplicationContext` or `ThemedReactContext` wherever a Context is expected.

I also fixed "receiveCommand: Wrong command received" getting logged every time compress is called.

@shahen94 