### PR TITLE
Check for crop's null startTime and endTime properly on Android

### DIFF
--- a/android/src/main/java/com/shahenlibrary/Trimmer/Trimmer.java
+++ b/android/src/main/java/com/shahenlibrary/Trimmer/Trimmer.java
@@ -649,14 +649,14 @@ public class Trimmer {
     // 3. "-to" (END TIME) or "-t" (TRIM TIME)
     // OTHERWISE WE WILL LOSE ACCURACY AND WILL GET WRONG CLIPPED VIDEO
 
-    String startTime = options.getString("startTime");
-    if ( !startTime.equals(null) && !startTime.equals("") ) {
+    String startTime = options.hasKey("startTime") ? options.getString("startTime") : null;
+    if ( startTime != null ) {
       cmd.add("-ss");
       cmd.add(startTime);
     }
 
-    String endTime = options.getString("endTime");
-    if ( !endTime.equals(null) && !endTime.equals("") ) {
+    String endTime = options.hasKey("endTime") ? options.getString("endTime") : null;
+    if ( endTime != null ) {
       cmd.add("-to");
       cmd.add(endTime);
     }


### PR DESCRIPTION
ReadableMap's `getString` will crash if the value is null and if that did work, `!startTime.equals(null)` will also crash. Also, the empty string value "" doesn't seem to ever make it to this method since the ProcessingManager converts it into something like "00:00:00.00".