### PR TITLE
BUGFIX: Problem of blocking default background thread

### DIFF
--- a/android/src/main/java/com/shahenlibrary/Trimmer/Trimmer.java
+++ b/android/src/main/java/com/shahenlibrary/Trimmer/Trimmer.java
@@ -743,7 +743,7 @@ public class Trimmer {
     FfmpegCmdAsyncTaskParams ffmpegCmdAsyncTaskParams = new FfmpegCmdAsyncTaskParams(cmd, pathToProcessingFile, ctx, promise, errorMessageTitle, cb);
 
     FfmpegCmdAsyncTask ffmpegCmdAsyncTask = new FfmpegCmdAsyncTask();
-    ffmpegCmdAsyncTask.execute(ffmpegCmdAsyncTaskParams);
+    ffmpegCmdAsyncTask.executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR ,ffmpegCmdAsyncTaskParams);
 
     return null;
   }
@@ -790,7 +790,7 @@ public class Trimmer {
     LoadFfmpegAsyncTaskParams loadFfmpegAsyncTaskParams = new LoadFfmpegAsyncTaskParams(ctx);
 
     LoadFfmpegAsyncTask loadFfmpegAsyncTask = new LoadFfmpegAsyncTask();
-    loadFfmpegAsyncTask.execute(loadFfmpegAsyncTaskParams);
+    loadFfmpegAsyncTask.executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR, loadFfmpegAsyncTaskParams);
 
     // TODO: EXPOSE TO JS "isFfmpegLoaded" AND "isFfmpegLoading"
 


### PR DESCRIPTION
AsyncTask.execute method runs on the background thread which is shared by every other module, in case of react-native, which causes the blockage of other background processes when video processing or trimming is going on. Changing it to AsyncTask.executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR, params) solves our problem.