### PR TITLE
Fixing Aspect Ratio Bug: `react native processing 'void android.graph…

### DIFF
--- a/android/src/main/java/com/shahenlibrary/Trimmer/Trimmer.java
+++ b/android/src/main/java/com/shahenlibrary/Trimmer/Trimmer.java
@@ -260,7 +260,7 @@ public class Trimmer {
       int height = Integer.parseInt(retriever.extractMetadata(FFmpegMediaMetadataRetriever.METADATA_KEY_VIDEO_HEIGHT));
       int orientation = Integer.parseInt(retriever.extractMetadata(FFmpegMediaMetadataRetriever.METADATA_KEY_VIDEO_ROTATION));
 
-      float aspectRatio = width / height;
+      float aspectRatio = (float)width / (float)height;
 
       int resizeWidth = 200;
       int resizeHeight = Math.round(resizeWidth / aspectRatio);


### PR DESCRIPTION
Due to non float result, the `aspectRatio` is getting `0` instead of `0.5`