### PR TITLE
Xcode 10.2

### DIFF
--- a/ios/RNVideoProcessing.xcodeproj/project.pbxproj
+++ b/ios/RNVideoProcessing.xcodeproj/project.pbxproj
@@ -25,6 +25,7 @@
 		24F466DA1DD9F1CB0012172B /* CoreVideo.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 24F4669B1DD9EB9B0012172B /* CoreVideo.framework */; };
 		24F466DB1DD9F1CB0012172B /* QuartzCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 24F4669E1DD9EBBD0012172B /* QuartzCore.framework */; };
 		24FFDD151DDC799E006040F9 /* MobileCoreServices.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 24FFDD141DDC799E006040F9 /* MobileCoreServices.framework */; };
+		B429F6152251F40500062EA7 /* AVUtilities.swift in Sources */ = {isa = PBXBuildFile; fileRef = B429F6142251F40500062EA7 /* AVUtilities.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -58,7 +59,7 @@
 		246271B31DDEF8AA003781DB /* RNVideoProcessingBridge.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RNVideoProcessingBridge.m; sourceTree = "<group>"; };
 		246271B41DDEF8AA003781DB /* RNVideoProcessingManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RNVideoProcessingManager.swift; sourceTree = "<group>"; };
 		246271B61DDEF8AA003781DB /* RNVideoTrimmer-Bridging-Header.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "RNVideoTrimmer-Bridging-Header.h"; sourceTree = "<group>"; };
-		246271B71DDEF8AA003781DB /* RNVideoTrimmer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RNVideoTrimmer.swift; sourceTree = "<group>"; };
+		246271B71DDEF8AA003781DB /* RNVideoTrimmer.swift */ = {isa = PBXFileReference; fileEncoding = 4; indentWidth = 2; lastKnownFileType = sourcecode.swift; path = RNVideoTrimmer.swift; sourceTree = "<group>"; tabWidth = 2; };
 		246271B81DDEF8AA003781DB /* RNVideoTrimmerBridge.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RNVideoTrimmerBridge.m; sourceTree = "<group>"; };
 		246271B91DDEF8AA003781DB /* VideoProcessingGPUFilters.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = VideoProcessingGPUFilters.swift; sourceTree = "<group>"; };
 		246271CD1DDEF8C6003781DB /* RNVideoProcessing.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RNVideoProcessing.h; sourceTree = "<group>"; };
@@ -70,6 +71,7 @@
 		24F4669E1DD9EBBD0012172B /* QuartzCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = QuartzCore.framework; path = System/Library/Frameworks/QuartzCore.framework; sourceTree = SDKROOT; };
 		24F466A01DD9EBC40012172B /* OpenGLES.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = OpenGLES.framework; path = System/Library/Frameworks/OpenGLES.framework; sourceTree = SDKROOT; };
 		24FFDD141DDC799E006040F9 /* MobileCoreServices.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = MobileCoreServices.framework; path = System/Library/Frameworks/MobileCoreServices.framework; sourceTree = SDKROOT; };
+		B429F6142251F40500062EA7 /* AVUtilities.swift */ = {isa = PBXFileReference; fileEncoding = 4; indentWidth = 2; lastKnownFileType = sourcecode.swift; path = AVUtilities.swift; sourceTree = "<group>"; tabWidth = 2; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -144,6 +146,7 @@
 				24F055831E2E4A92009E0196 /* SDAVAssetExportSession */,
 				246271B61DDEF8AA003781DB /* RNVideoTrimmer-Bridging-Header.h */,
 				246271B71DDEF8AA003781DB /* RNVideoTrimmer.swift */,
+				B429F6142251F40500062EA7 /* AVUtilities.swift */,
 				246271B81DDEF8AA003781DB /* RNVideoTrimmerBridge.m */,
 			);
 			path = RNVideoTrimmer;
@@ -220,6 +223,7 @@
 			developmentRegion = English;
 			hasScannedForEncodings = 0;
 			knownRegions = (
+				English,
 				en,
 			);
 			mainGroup = 58B511D21A9E6C8500147676;
@@ -244,6 +248,7 @@
 				246271C01DDEF8AA003781DB /* RNVideoPlayer.swift in Sources */,
 				246271BE1DDEF8AA003781DB /* RNTrimmerViewBridge.m in Sources */,
 				246271BD1DDEF8AA003781DB /* RNTrimmerView.swift in Sources */,
+				B429F6152251F40500062EA7 /* AVUtilities.swift in Sources */,
 				246271C11DDEF8AA003781DB /* RNVideoProcessingBridge.m in Sources */,
 				246271C51DDEF8AA003781DB /* VideoProcessingGPUFilters.swift in Sources */,
 				246271C31DDEF8AA003781DB /* RNVideoTrimmer.swift in Sources */,
@@ -347,7 +352,7 @@
 				SKIP_INSTALL = YES;
 				SWIFT_OBJC_BRIDGING_HEADER = "RNVideoProcessing-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 3.0;
+				SWIFT_VERSION = 4.2;
 			};
 			name = Debug;
 		};
@@ -367,7 +372,7 @@
 				PRODUCT_NAME = RNVideoProcessing;
 				SKIP_INSTALL = YES;
 				SWIFT_OBJC_BRIDGING_HEADER = "RNVideoProcessing-Bridging-Header.h";
-				SWIFT_VERSION = 3.0;
+				SWIFT_VERSION = 4.2;
 			};
 			name = Release;
 		};

--- a/ios/RNVideoProcessing.xcodeproj/project.pbxproj
+++ b/ios/RNVideoProcessing.xcodeproj/project.pbxproj
@@ -72,6 +72,7 @@
 		24F466A01DD9EBC40012172B /* OpenGLES.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = OpenGLES.framework; path = System/Library/Frameworks/OpenGLES.framework; sourceTree = SDKROOT; };
 		24FFDD141DDC799E006040F9 /* MobileCoreServices.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = MobileCoreServices.framework; path = System/Library/Frameworks/MobileCoreServices.framework; sourceTree = SDKROOT; };
 		B429F6142251F40500062EA7 /* AVUtilities.swift */ = {isa = PBXFileReference; fileEncoding = 4; indentWidth = 2; lastKnownFileType = sourcecode.swift; path = AVUtilities.swift; sourceTree = "<group>"; tabWidth = 2; };
+		B429F7102252496D00062EA7 /* RCTSwiftBridgeModule.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RCTSwiftBridgeModule.h; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -103,6 +104,7 @@
 			children = (
 				246271B21DDEF8AA003781DB /* RNVideoProcessing-Bridging-Header.h */,
 				246271CD1DDEF8C6003781DB /* RNVideoProcessing.h */,
+				B429F7102252496D00062EA7 /* RCTSwiftBridgeModule.h */,
 				246271B31DDEF8AA003781DB /* RNVideoProcessingBridge.m */,
 				246271B11DDEF8AA003781DB /* RNVideoPlayer.swift */,
 				246271B41DDEF8AA003781DB /* RNVideoProcessingManager.swift */,

--- a/ios/RNVideoProcessing/RCTSwiftBridgeModule.h
+++ b/ios/RNVideoProcessing/RCTSwiftBridgeModule.h
@@ -1,0 +1,29 @@
+//
+//  RCTSwiftBridgeModule.h
+//  AwesomeProject
+//
+//  Created by Slava Semeniuk on 4/1/19.
+//  Copyright © 2019 Facebook. All rights reserved.
+//
+
+#ifndef RCTSwiftBridgeModule_h
+#define RCTSwiftBridgeModule_h
+
+#define RCT_EXTERN_SWIFT_MODULE(objc_name, objc_supername) \
+RCT_EXTERN_REMAP_SWIFT_MODULE(, objc_name, objc_supername)
+
+#define RCT_EXTERN_REMAP_SWIFT_MODULE(js_name, objc_name, objc_supername) \
+objc_name : objc_supername \
+@end \
+@interface objc_name (RCTExternModule) <RCTBridgeModule> \
+@end \
+@implementation objc_name (RCTExternModule) \
+RCT_EXPORT_SWIFT_MODULE(js_name, objc_name)
+
+#define RCT_EXPORT_SWIFT_MODULE(js_name, objc_name) \
+RCT_EXTERN void RCTRegisterModule(Class); \
++ (NSString *)moduleName { return @#js_name; } \
+__attribute__((constructor)) static void \
+RCT_CONCAT(initialize_, objc_name)() { RCTRegisterModule([objc_name class]); }
+
+#endif /* RCTSwiftBridgeModule_h */

--- a/ios/RNVideoProcessing/RNTrimmerView/RNTrimmerViewBridge.m
+++ b/ios/RNVideoProcessing/RNTrimmerView/RNTrimmerViewBridge.m
@@ -7,8 +7,9 @@
 
 #import "React/RCTBridgeModule.h"
 #import "React/RCTViewManager.h"
+#import "RCTSwiftBridgeModule.h"
 
-@interface RCT_EXTERN_MODULE(RNTrimmerViewManager, RCTViewManager)
+@interface RCT_EXTERN_SWIFT_MODULE(RNTrimmerViewManager, RCTViewManager)
 
 RCT_EXPORT_VIEW_PROPERTY(source, NSString)
 RCT_EXPORT_VIEW_PROPERTY(width, NSNumber)

--- a/ios/RNVideoProcessing/RNVideoProcessingBridge.m
+++ b/ios/RNVideoProcessing/RNVideoProcessingBridge.m
@@ -7,8 +7,9 @@
 
 #import "React/RCTBridgeModule.h"
 #import "React/RCTViewManager.h"
+#import "RCTSwiftBridgeModule.h"
 
-@interface RCT_EXTERN_MODULE(RNVideoProcessingManager, RCTViewManager)
+@interface RCT_EXTERN_SWIFT_MODULE(RNVideoProcessingManager, RCTViewManager)
 
 RCT_EXPORT_VIEW_PROPERTY(source, NSString)
 RCT_EXPORT_VIEW_PROPERTY(currentTime, NSNumber)

--- a/ios/RNVideoProcessing/RNVideoProcessingManager.swift
+++ b/ios/RNVideoProcessing/RNVideoProcessingManager.swift
@@ -6,6 +6,8 @@
 //
 
 import Foundation
+import AVFoundation
+import UIKit
 
 @objc(RNVideoProcessingManager)
 class RNVideoProcessingManager: RCTViewManager {
@@ -16,10 +18,10 @@ class RNVideoProcessingManager: RCTViewManager {
 
     @objc override func constantsToExport() -> [AnyHashable: Any] {
         return [
-            "ScaleNone": AVLayerVideoGravityResizeAspect,
-            "ScaleToFill": AVLayerVideoGravityResize,
-            "ScaleAspectFit": AVLayerVideoGravityResizeAspect,
-            "ScaleAspectFill": AVLayerVideoGravityResizeAspectFill
+            "ScaleNone": AVLayerVideoGravity.resizeAspect,
+            "ScaleToFill": AVLayerVideoGravity.resize,
+            "ScaleAspectFit": AVLayerVideoGravity.resizeAspect,
+            "ScaleAspectFill": AVLayerVideoGravity.resizeAspectFill
         ]
     }
 

--- a/ios/RNVideoProcessing/RNVideoTrimmer/AVUtilities.swift
+++ b/ios/RNVideoProcessing/RNVideoTrimmer/AVUtilities.swift
@@ -19,7 +19,7 @@ class AVUtilities {
       return
     }
     
-    guard let videoTrack = original.tracks(withMediaType: AVMediaTypeVideo).last else {
+    guard let videoTrack = original.tracks(withMediaType: .video).last else {
       print("could not retrieve the video track.")
       return
     }
@@ -41,7 +41,7 @@ class AVUtilities {
     
     let writer: AVAssetWriter
     do {
-      writer = try AVAssetWriter(outputURL: outputURL, fileType: AVFileTypeQuickTimeMovie)
+      writer = try AVAssetWriter(outputURL: outputURL, fileType: .mov)
     } catch let error {
       fatalError(error.localizedDescription)
     }
@@ -54,7 +54,7 @@ class AVUtilities {
       AVVideoCompressionPropertiesKey: videoCompositionProps
       ] as [String : Any]
     
-    let writerInput = AVAssetWriterInput(mediaType: AVMediaTypeVideo, outputSettings: writerOutputSettings)
+    let writerInput = AVAssetWriterInput(mediaType: .video, outputSettings: writerOutputSettings)
     writerInput.expectsMediaDataInRealTime = false
     writerInput.transform = videoTrack.preferredTransform
     
@@ -79,5 +79,3 @@ class AVUtilities {
     }
   }
 }
-
-

--- a/ios/RNVideoProcessing/RNVideoTrimmer/RNVideoTrimmerBridge.m
+++ b/ios/RNVideoProcessing/RNVideoTrimmer/RNVideoTrimmerBridge.m
@@ -6,8 +6,9 @@
 #import <Foundation/Foundation.h>
 
 #import "React/RCTBridgeModule.h"
+#import "RCTSwiftBridgeModule.h"
 
-@interface RCT_EXTERN_MODULE(RNVideoTrimmer, NSObject)
+@interface RCT_EXTERN_SWIFT_MODULE(RNVideoTrimmer, NSObject)
 
 RCT_EXTERN_METHOD(getAssetInfo:(NSString *)source callback:(RCTResponseSenderBlock)callback);
 RCT_EXTERN_METHOD(trim:(NSString *)source options:(NSDictionary *)options callback:(RCTResponseSenderBlock)callback);


### PR DESCRIPTION
1. Migrate code to swift 4.2.
2. Add macro for register swift classes as modules (RCTSwiftBridgeModule.h). 
Xcode 10.2 forbids creating categories for swift class that uses `+load` method. In react-native categories like this are used to register swift classes as modules (macro `RCT_EXTERN_MODULE`) 
A similar solution has already been committed to react-native repo but it's not released yet. (https://github.com/facebook/react-native/commit/ff66600224e78fec5d0e902f8a035b78ed31a961).