### PR TITLE
Use UIManager.getViewManagerConfig

### DIFF
--- a/lib/VideoPlayer/VideoPlayer.android.js
+++ b/lib/VideoPlayer/VideoPlayer.android.js
@@ -14,7 +14,7 @@ import {
 } from 'react-native';
 import { getActualSource } from '../utils';
 
-const ProcessingUI = UIManager.RNVideoProcessing;
+const ProcessingUI = UIManager.getViewManagerConfig('RNVideoProcessing');
 
 export class VideoPlayer extends Component {
   static Constants = {

--- a/lib/VideoPlayer/VideoPlayer.ios.js
+++ b/lib/VideoPlayer/VideoPlayer.ios.js
@@ -6,6 +6,8 @@ const PLAYER_COMPONENT_NAME = 'RNVideoProcessing';
 
 const { RNVideoTrimmer } = NativeModules;
 
+const ProcessingUI = UIManager.getViewManagerConfig('RNVideoProcessing');
+
 export class VideoPlayer extends Component {
   static propTypes = {
     source: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
@@ -28,7 +30,7 @@ export class VideoPlayer extends Component {
     play: false,
     replay: false,
     rotate: false,
-    resizeMode: UIManager.RNVideoProcessing.Constants.ScaleNone,
+    resizeMode: ProcessingUI.Constants.ScaleNone,
     volume: 0.0,
     currentTime: 0,
     startTime: 0,
@@ -47,10 +49,10 @@ export class VideoPlayer extends Component {
       QUALITY_PASS_THROUGH: 'passthrough', // does not change quality
     },
     resizeMode: {
-      CONTAIN: UIManager.RNVideoProcessing.Constants.ScaleAspectFit,
-      COVER: UIManager.RNVideoProcessing.Constants.ScaleAspectFill,
-      STRETCH: UIManager.RNVideoProcessing.Constants.ScaleToFill,
-      NONE: UIManager.RNVideoProcessing.Constants.ScaleNone
+      CONTAIN: ProcessingUI.Constants.ScaleAspectFit,
+      COVER: ProcessingUI.Constants.ScaleAspectFill,
+      STRETCH: ProcessingUI.Constants.ScaleToFill,
+      NONE: ProcessingUI.Constants.ScaleNone
     }
   };
 


### PR DESCRIPTION
Fixes warning:

>Accessing view manager configs directly off UIManager via UIManager['RNVideoProcessing']
     is no longer supported. Use UIManager.getViewManagerConfig('RNVideoProcessing') instead.