### PR TITLE
Update Trimmer.java

### DIFF
--- a/android/src/main/java/com/shahenlibrary/Trimmer/Trimmer.java
+++ b/android/src/main/java/com/shahenlibrary/Trimmer/Trimmer.java
@@ -477,7 +477,7 @@ public class Trimmer {
       FFmpegMediaMetadataRetriever.IN_PREFERRED_CONFIG = Bitmap.Config.ARGB_8888;
       metadataRetriever.setDataSource(source);
 
-      bmp = metadataRetriever.getFrameAtTime((long) (sec * 1000000));
+      bmp = metadataRetriever.getFrameAtTime((long) (sec * 1000000), FFmpegMediaMetadataRetriever.OPTION_CLOSEST);
       if(bmp == null){
         promise.reject("Failed to get preview at requested position.");
         return;


### PR DESCRIPTION
Add FFmpegMediaMetadataRetriever.OPTION_CLOSEST option to line 480 where bmp is generated to retrieve a frame that may or may not be a sync frame but is closest to or the same as time. 

In reference to #255 