### PR TITLE
Swap out ViewPropTypes to deprecated-react-native-prop-types

### DIFF
--- a/lib/VideoPlayer/VideoPlayer.android.js
+++ b/lib/VideoPlayer/VideoPlayer.android.js
@@ -9,9 +9,9 @@ import {
   requireNativeComponent,
   CameraRoll,
   UIManager,
-  findNodeHandle,
-  ViewPropTypes
+  findNodeHandle
 } from 'react-native';
+import { ViewPropTypes } from 'deprecated-react-native-prop-types';
 import { getActualSource } from '../utils';
 
 const ProcessingUI = UIManager.getViewManagerConfig('RNVideoProcessing');

--- a/lib/VideoPlayer/VideoPlayer.ios.js
+++ b/lib/VideoPlayer/VideoPlayer.ios.js
@@ -1,6 +1,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { View, ViewPropTypes, requireNativeComponent, NativeModules, UIManager } from 'react-native';
+import { View, requireNativeComponent, NativeModules, UIManager } from 'react-native';
+import { ViewPropTypes } from 'deprecated-react-native-prop-types';
 import { getActualSource } from '../utils';
 const PLAYER_COMPONENT_NAME = 'RNVideoProcessing';
 


### PR DESCRIPTION
This fixes an issue in newer react native versions that doesn't allow using view prop types unless they're pulled from deprecated-react-native-prop-types