### PR TITLE
Fix: Unreported IOException on MediaMetadataRetriever.release() with target SDK 33 (Android)

### DIFF
--- a/android/src/main/java/com/shahenlibrary/Trimmer/Trimmer.java
+++ b/android/src/main/java/com/shahenlibrary/Trimmer/Trimmer.java
@@ -374,7 +374,11 @@ public class Trimmer {
       videoMetadata.putInt("bitrate", bitrate);
       return videoMetadata;
     } finally {
-      retriever.release();
+      try {
+        retriever.release();
+      } catch (IOException e) {
+        e.printStackTrace();
+      }
     }
   }
 


### PR DESCRIPTION
I've updated the target SDK version to 33 in my React Native application. However, while building, Gradle raises concerns regarding an unreported IOException stemming from the execution of `MediaMetadataRetriever.release()`.

The exception was added in [API level 33](https://developer.android.com/reference/android/media/MediaMetadataRetriever#release()).

I believe that incorporating a try-catch block would be the most prudent approach in this situation. This way, if an exception is thrown during the release process for any unforeseen reason (such as if the system has already initiated the release), the application will avoid crashing. I would like to mention that this approach has been tested, and now the app compiles successfully.

Closes #372 